### PR TITLE
V0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de45108900e1f9b9242f7f2e254aa3e2c029c921c258fe9e6b4217eeebd54288"
 dependencies = [
  "axum-core",
+ "axum-macros",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -73,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "axum-distributed-routing"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "axum",
  "axum-distributed-routing-macros",
@@ -82,11 +83,22 @@ dependencies = [
 
 [[package]]
 name = "axum-distributed-routing-macros"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "proc-macro2",
  "quote",
  "stringcase",
+ "syn",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
+dependencies = [
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -173,11 +185,12 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hello_world"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "axum",
  "axum-distributed-routing",
  "linkme",
+ "serde",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "axum-distributed-routing"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = """
 Distributed routing for axum

--- a/axum-distributed-routing-macros/Cargo.toml
+++ b/axum-distributed-routing-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-distributed-routing-macros"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = """
 Distributed routing macros for axum

--- a/axum-distributed-routing-macros/src/lib.rs
+++ b/axum-distributed-routing-macros/src/lib.rs
@@ -90,7 +90,7 @@ impl Parse for Args {
                             "CONNECT" => method = Some(Method::Connect),
                             m => {
                                 return Err(syn::Error::new(
-                                    proc_macro2::Span::call_site(),
+                                    ident.span(),
                                     format!("Unknown method {}", m),
                                 ));
                             }
@@ -234,7 +234,7 @@ impl Args {
                             })?;
                         let param_type = proc_macro2::TokenStream::from_str(&current_type)
                             .map_err(|_| {
-                                syn::Error::new(proc_macro2::Span::call_site(), "Invalid path parameter type")
+                                syn::Error::new(literal.span(), "Invalid path parameter type")
                             })?;
                         path_params.insert(syn::parse2(param_name)?, syn::parse2(param_type)?);
 

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "hello_world"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 publish = false
 
 [dependencies]
-axum = "0.8.1"
+axum = { version = "0.8.1", features = ["macros"] }
 linkme = "0.3.32"
 axum-distributed-routing = { path = "../../" }
 tokio = { version = "1.44.1", features = ["rt-multi-thread"] }
+serde = { version = "1.0.219", features = ["derive"] }

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -1,7 +1,9 @@
 use axum::http::StatusCode;
+use axum::Json;
 use axum_distributed_routing::create_router;
 use axum_distributed_routing::route;
 use axum_distributed_routing::route_group;
+use serde::Deserialize;
 
 // Create the root route group
 route_group!(Routes, ());
@@ -9,11 +11,41 @@ route_group!(Routes, ());
 // You can nest groups
 route_group!(pub Api, (), Routes, "/api");
 
+#[derive(Deserialize)]
+pub struct ExprQuery {
+    pub times: i32,
+}
+
+#[derive(Deserialize)]
+pub struct ExprBody {
+    pub plus: i32,
+}
+
+// Create a route
 route!(
     group = Routes,
-    path = "/echo/{str:String}",
     method = GET,
-    async test_fn -> String { str }
+
+    // You can define path parameters...
+    path = "/expr/{val:i32}",
+
+    // ...query parameters...
+    query = ExprQuery,
+
+    // ...and body parameters.
+    body = Json<ExprBody>,
+
+    // You can also add attributes to the handler
+    #[axum::debug_handler]
+    async test_fn -> String {
+        format!(
+            "{} * {} + {} = {}",
+            val,
+            query.times,
+            body.plus,
+            val * query.times + body.plus
+        )
+    }
 );
 
 route!(


### PR DESCRIPTION
# CHANGELOG

## Breaking
- It is no longer possible to inline a struct definition in query and body parameters
- `async` keyword is now required

## Features
- Add support for attributes on the handler
- Improved error reporting
- The handler is now defined as a standalone function